### PR TITLE
Generalize transfer queue and two more probes

### DIFF
--- a/common/check_messages_to_submit
+++ b/common/check_messages_to_submit
@@ -8,19 +8,24 @@
 # Authors:
 # - Mario Lassnig, <mario.lassnig@cern.ch>, 2013-2014
 
-'''
+"""
 Probe to check the queues of messages to submit by Hermes to the broker
-'''
+"""
 
 import sys
 
 from rucio.core import monitor
-from rucio.db.sqla.session import get_session
+from rucio.db.sqla.session import BASE, get_session
 
 # Exit statuses
 OK, WARNING, CRITICAL, UNKNOWN = 0, 1, 2, 3
 
-queue_sql = """SELECT COUNT(*) FROM atlas_rucio.messages"""
+if BASE.metadata.schema:
+    schema = BASE.metadata.schema + '.'
+else:
+    schema = ''
+
+queue_sql = """SELECT COUNT(*) FROM {schema}messages""".format(schema=schema)
 
 if __name__ == "__main__":
     try:
@@ -34,6 +39,6 @@ if __name__ == "__main__":
         elif result[0][0] > 1000000:
             sys.exit(CRITICAL)
 
-    except Exception, e:
+    except Exception as e:
         sys.exit(UNKNOWN)
     sys.exit(OK)

--- a/common/check_transfer_queues_status
+++ b/common/check_transfer_queues_status
@@ -10,17 +10,22 @@
 # - Cedric Serfon, <cedric.serfon@cern.ch>, 2014
 # - Wen Guan, <wen.guan@cern.ch>, 2015
 
-'''
+"""
 Probe to check the queues of the transfer service
-'''
+"""
 
 import sys
 
 from rucio.core import monitor
-from rucio.db.sqla.session import get_session
+from rucio.db.sqla.session import BASE, get_session
 
 # Exit statuses
 OK, WARNING, CRITICAL, UNKNOWN = 0, 1, 2, 3
+
+if BASE.metadata.schema:
+    schema = BASE.metadata.schema + '.'
+else:
+    schema = ''
 
 active_queue = """SELECT
 CASE
@@ -36,9 +41,9 @@ num_rows
 FROM
 (
 select state, count(*) num_rows, activity, external_host
-FROM atlas_rucio.requests
+FROM {schema}requests
 GROUP BY state, activity, external_host
-)"""
+)""".format(schema=schema)
 
 if __name__ == "__main__":
     try:

--- a/common/check_unevaluated_dids
+++ b/common/check_unevaluated_dids
@@ -8,22 +8,29 @@
 # Authors:
 # - Vincent Garonne, <vincent.garonne@cern.ch>, 2013
 
-'''
+"""
 Probe to check the backlog of dids waiting for rule evaluation.
-'''
+"""
 
 import sys
 
 from rucio.core import monitor
-from rucio.db.sqla.session import get_session
+from rucio.db.sqla.session import BASE, get_session
 
 # Exit statuses
 OK, WARNING, CRITICAL, UNKNOWN = 0, 1, 2, 3
 
+if BASE.metadata.schema:
+    schema = BASE.metadata.schema + '.'
+else:
+    schema = ''
+
+count_sql = 'SELECT COUNT(*) FROM {schema}updated_dids'.format(schema=schema)
+
 if __name__ == "__main__":
     try:
         session = get_session()
-        result = session.execute('SELECT COUNT(*) FROM ATLAS_RUCIO.updated_dids').fetchone()[0]
+        result = session.execute(count_sql).fetchone()[0]
         monitor.record_gauge(stat='judge.waiting_dids', value=result)
         print result
     except:


### PR DESCRIPTION
This changes a few probes to no longer use the ATLAS DB namespace.