### PR TITLE
Set greedyDeletion attribute for select RSEs

### DIFF
--- a/common/check_rse_attributes
+++ b/common/check_rse_attributes
@@ -150,6 +150,8 @@ if __name__ == '__main__':
                 add_rse_attribute(name, 'datapolicyt0tape', 'T0Tape' in rse['datapolicies'], session=session)
                 add_rse_attribute(name, 'datapolicyt0taskoutput', 'T0TaskOutput' in rse['datapolicies'], session=session)
                 add_rse_attribute(name, 'datapolicynucleus', 'Nucleus' in rse['datapolicies'], session=session)
+            if rse['type'] in ('CALIBDISK', 'GROUPDISK', 'LOCALGROUPDISK'):
+                add_rse_attribute(name, 'greedyDeletion', True, session=session)
 
             space_used = get_rse_usage(rse=name, source='storage', session=session)
             unavailable_space = get_rse_usage(rse=name, source='unavailable', session=session)


### PR DESCRIPTION
Previously, CALIBDISKs, GROUPDISKs and LOCALGROUPDISKs we handled by a
special Reaper instance which was running in greedy mode. The new Reaper
implementation requires that an attribute is set instead.