### PR TITLE
Allow a prefix to be defined in the config file

### DIFF
--- a/common/check_expired_rules
+++ b/common/check_expired_rules
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright European Organization for Nuclear Research (CERN) 2013
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -8,13 +8,11 @@
 # Authors:
 # - Vincent Garonne, <vincent.garonne@cern.ch>, 2013
 # - Thomas Beermann, <thomas.beermann@cern.ch>, 2019
-# - Eric Vaandering, <ewv@fnal.gov>, 2020
+# - Eric Vaandering, <ewv@fnal.gov>, 2020-2021
 
-'''
+"""
 Probe to check the backlog of expired rules.
-'''
-
-from __future__ import print_function, absolute_import, division
+"""
 
 import sys
 import traceback
@@ -40,11 +38,11 @@ if __name__ == "__main__":
         session = get_session()
         expired_rules = 'select count(1) from {schema}rules where expires_at < sys_extract_utc(localtimestamp)'.format(schema=schema)
         result = session.execute(expired_rules).fetchone()[0]
-        monitor.record_gauge(stat='judge.expired_rules', value=result)
+        monitor.record_gauge('judge.expired_rules', value=result)
         Gauge(PROM_PREFIX + 'judge_expired_rules', '', registry=registry).set(result)
         lifetimed_rules = 'select count(1) from {schema}rules where expires_at > sys_extract_utc(localtimestamp)'.format(schema=schema)
         result = session.execute(lifetimed_rules).fetchone()[0]
-        monitor.record_gauge(stat='judge.lifetimed_rules', value=result)
+        monitor.record_gauge('judge.lifetimed_rules', value=result)
         Gauge(PROM_PREFIX + 'judge_lifetimed_rules', '', registry=registry).set(result)
 
         if len(PROM_SERVERS):

--- a/common/check_expired_rules
+++ b/common/check_expired_rules
@@ -8,16 +8,19 @@
 # Authors:
 # - Vincent Garonne, <vincent.garonne@cern.ch>, 2013
 # - Thomas Beermann, <thomas.beermann@cern.ch>, 2019
+# - Eric Vaandering, <ewv@fnal.gov>, 2020
 
 '''
 Probe to check the backlog of expired rules.
 '''
+
+from __future__ import print_function, absolute_import, division
+
 import sys
 import traceback
 
 from prometheus_client import CollectorRegistry, Gauge, push_to_gateway
-
-from rucio.common.config import config_get
+from probe_utils import get_prometheus_config
 from rucio.core import monitor
 from rucio.db.sqla.session import BASE, get_session
 
@@ -29,9 +32,7 @@ if BASE.metadata.schema:
 else:
     schema = ''
 
-PROM_SERVERS = config_get('monitor', 'prometheus_servers', raise_exception=False, default='')
-if PROM_SERVERS != '':
-    PROM_SERVERS = PROM_SERVERS.split(',')
+PROM_SERVERS, PROM_PREFIX, PROM_LABELS = get_prometheus_config()
 
 if __name__ == "__main__":
     try:
@@ -40,21 +41,22 @@ if __name__ == "__main__":
         expired_rules = 'select count(1) from {schema}rules where expires_at < sys_extract_utc(localtimestamp)'.format(schema=schema)
         result = session.execute(expired_rules).fetchone()[0]
         monitor.record_gauge(stat='judge.expired_rules', value=result)
-        Gauge('judge_expired_rules', '', registry=registry).set(result)
+        Gauge(PROM_PREFIX + 'judge_expired_rules', '', registry=registry).set(result)
         lifetimed_rules = 'select count(1) from {schema}rules where expires_at > sys_extract_utc(localtimestamp)'.format(schema=schema)
         result = session.execute(lifetimed_rules).fetchone()[0]
         monitor.record_gauge(stat='judge.lifetimed_rules', value=result)
-        Gauge('judge_lifetimed_rules', '', registry=registry).set(result)
+        Gauge(PROM_PREFIX + 'judge_lifetimed_rules', '', registry=registry).set(result)
 
         if len(PROM_SERVERS):
             for server in PROM_SERVERS:
                 try:
-                    push_to_gateway(server.strip(), job='check_expired_rules', registry=registry)
+                    push_to_gateway(server.strip(), job='check_expired_rules', registry=registry,
+                                    grouping_key=PROM_LABELS)
                 except:
                     continue
 
-        print result
+        print(result)
     except:
-        print traceback.format_exc()
+        print(traceback.format_exc())
         sys.exit(UNKNOWN)
     sys.exit(OK)

--- a/common/probe_utils.py
+++ b/common/probe_utils.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python
+# Copyright European Organization for Nuclear Research (CERN) 2020
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# Authors:
+# - Eric Vaandering, <ewv@fnal.gov>, 2020
+
+import json
+
+from rucio.common.config import config_get
+
+
+def get_prometheus_config():
+    prom_servers = config_get('monitor', 'prometheus_servers', raise_exception=False, default='')
+    if prom_servers != '':
+        prom_servers = prom_servers.split(',')
+    prom_prefix = config_get('monitor', 'prometheus_prefix', raise_exception=False, default='')
+    prom_label_config = config_get('monitor', 'prometheus_labels', raise_exception=False, default=None)
+    if prom_label_config:
+        try:
+            prom_labels = json.loads(prom_label_config)
+        except ValueError:
+            prom_labels = None
+    else:
+        prom_labels = None
+    return prom_servers, prom_prefix, prom_labels


### PR DESCRIPTION
@tbeerman: @dchristidis wanted your review of this.

The point here is to be able to define a prefix, via k8s, which gets prepended to the metrics for different instances