### PR TITLE
Make cms used probes python3 compatible

### DIFF
--- a/common/check_fts_backlog
+++ b/common/check_fts_backlog
@@ -12,11 +12,14 @@
  - Eric Vaandering, <ewv@fnal.gov>, 2019
  - Thomas Beermann, <thomas.beermann@cern.ch>, 2019
 """
-
+from __future__ import print_function
 import os
 import sys
-from urlparse import urlparse
 import urllib3
+try:
+    from urlparse import urlparse
+except ImportError:
+    from urllib.parse import urlparse
 
 from prometheus_client import CollectorRegistry, Gauge, push_to_gateway
 import requests
@@ -63,14 +66,14 @@ if __name__ == "__main__":
         PROXY = config_get('nagios', 'proxy')
         os.environ["X509_USER_PROXY"] = PROXY
     except Exception as error:
-        print "Failed to get proxy from rucio.cfg"
+        print("Failed to get proxy from rucio.cfg")
         PROXY = '/opt/rucio/etc/ddmusr01.rfc.proxy'
         WORST_RETVALUE = WARNING
 
     try:
         FTSHOSTS = config_get('conveyor', 'ftsmonhosts')
     except Exception as error:
-        print "Failed to get ftsmonhosts"
+        print("Failed to get ftsmonhosts")
         FTSHOSTS = []
         WORST_RETVALUE = WARNING
 
@@ -90,7 +93,7 @@ if __name__ == "__main__":
         url = '%s/fts3/ftsmon/overview?dest_se=&source_se=&time_window=1&vo=%s' % (ftshost, VO)
         busy_channels = []
         busylimit = 5000
-        for attempt in xrange(0, 5):
+        for attempt in range(0, 5):
             result = None
             try:
                 result = requests.get(url, verify=False, cert=(PROXY, PROXY))
@@ -125,16 +128,16 @@ if __name__ == "__main__":
                                               'activities': activities})
                 summary = res['summary']
                 hostname = hostname.replace('.', '_')
-                print '%s : Submitted : %s' % (hostname, summary['submitted'])
-                print '%s : Active : %s' % (hostname, summary['active'])
-                print '%s : Staging : %s' % (hostname, summary['staging'])
-                print '%s : Started : %s' % (hostname, summary['started'])
+                print('%s : Submitted : %s' % (hostname, summary['submitted']))
+                print('%s : Active : %s' % (hostname, summary['active']))
+                print('%s : Staging : %s' % (hostname, summary['staging']))
+                print('%s : Started : %s' % (hostname, summary['started']))
                 if busy_channels != []:
                     print('Busy channels (>%s submitted):' % busylimit)
                     for bc in busy_channels:
                         activities_str = ", ".join([("%s: %s" % (key, val)) for key, val in bc['activities'].items()])
-                        print '  %s to %s : %s submitted jobs (%s)' % (bc['src'], bc['dst'], bc['submitted'],
-                                                                       str(activities_str))
+                        print('  %s to %s : %s submitted jobs (%s)' % (bc['src'], bc['dst'], bc['submitted'],
+                                                                       str(activities_str)))
                 monitor.record_gauge(stat='fts3.%s.submitted' % hostname,
                                      value=(summary['submitted'] + summary['active']
                                             + summary['staging'] + summary['started']))

--- a/common/check_messages_to_submit
+++ b/common/check_messages_to_submit
@@ -12,6 +12,7 @@
 """
 Probe to check the queues of messages to submit by Hermes to the broker
 """
+from __future__ import print_function
 
 import sys
 
@@ -40,7 +41,7 @@ if __name__ == "__main__":
         registry = CollectorRegistry()
         session = get_session()
         result = session.execute(queue_sql).fetchall()
-        print 'queues.messages %s' % result[0][0]
+        print('queues.messages %s' % result[0][0])
         monitor.record_gauge(stat='queues.messages', value=result[0][0])
         Gauge('hermes_queues_messages', '', registry=registry).set(result[0][0])
 

--- a/common/check_oracle
+++ b/common/check_oracle
@@ -14,6 +14,7 @@
 """
 Probe to check Oracle.
 """
+from __future__ import print_function
 
 import sys
 
@@ -32,7 +33,7 @@ if __name__ == "__main__":
         user = config_get('database', 'powuseraccount', raise_exception=False, default=None)
         password = config_get('database', 'powuserpassword', raise_exception=False, default=None)
     except:
-        print 'Cannot get DB parameters'
+        print('Cannot get DB parameters')
         sys.exit(CRITICAL)
 
     if not (user and password):
@@ -41,7 +42,7 @@ if __name__ == "__main__":
             up = upp.split('://')[1]            # user:password
             user, password = up.split(':')
         except:
-            print 'Cannot guess DB parameters'
+            print('Cannot guess DB parameters')
             sys.exit(CRITICAL)
 
     dsn = sql_connection.split('@')[1]
@@ -62,7 +63,7 @@ ORDER BY inst_id, mname.metric_name, mname.metric_unit'''
         cursor.execute(query)
         for (metric, value) in cursor:
             m = 'oracle.%s' % metric.replace(' ', '_')
-            print m, value, ' ',
+            print(m, value, ' ')
             monitor.record_gauge(stat=m, value=value)
     except:
         sys.exit(UNKNOWN)

--- a/common/check_stuck_rules
+++ b/common/check_stuck_rules
@@ -13,12 +13,12 @@
 """
 Probe to check the backlog of stuck rules.
 """
+from __future__ import print_function
 
 import sys
 import traceback
 
 from prometheus_client import CollectorRegistry, Gauge, push_to_gateway
-
 from rucio.common.config import config_get
 from rucio.core import monitor
 from rucio.db.sqla.session import BASE, get_session
@@ -58,6 +58,6 @@ if __name__ == "__main__":
                 except:
                     continue
     except:
-        print traceback.format_exc()
+        print(traceback.format_exc())
         sys.exit(UNKNOWN)
     sys.exit(OK)

--- a/common/check_transfer_queues_status
+++ b/common/check_transfer_queues_status
@@ -14,6 +14,7 @@
 """
 Probe to check the queues of the transfer service
 """
+from __future__ import print_function
 
 import sys
 
@@ -65,7 +66,7 @@ if __name__ == "__main__":
         g = Gauge('conveyor_queues_requests', '', labelnames=('state', 'activity', 'external_host'), registry=registry)
         session = get_session()
         for k in session.execute(active_queue).fetchall():
-            print k[0], k[1],
+            print(k[0], k[1], end=" ")
             monitor.record_gauge(stat=k[0], value=k[1])
             items = k[0].split('.')
             state = items[2]

--- a/common/check_unevaluated_dids
+++ b/common/check_unevaluated_dids
@@ -12,6 +12,7 @@
 """
 Probe to check the backlog of dids waiting for rule evaluation.
 """
+from __future__ import print_function
 
 import sys
 
@@ -51,7 +52,7 @@ if __name__ == "__main__":
                 except:
                     continue
 
-        print result
+        print(result)
     except:
         sys.exit(UNKNOWN)
     sys.exit(OK)

--- a/common/check_unlocked_replicas
+++ b/common/check_unlocked_replicas
@@ -12,6 +12,7 @@
 """
 Probe to check the backlog of unlocked replicas.
 """
+from __future__ import print_function
 
 import sys
 
@@ -51,7 +52,7 @@ if __name__ == "__main__":
         result = session.execute(unlocked_sql).fetchone()[0]
         monitor.record_gauge(stat='reaper.unlocked_replicas', value=result)
         Gauge('reaper_unlocked_replicas', '', registry=registry).set(result)
-        print result
+        print(result)
         expired_sql = 'select  /*+ index_ffs(replicas REPLICAS_TOMBSTONE_IDX) */  count(1) from {schema}replicas where tombstone is not null and tombstone < sysdate - 2/24'.format(schema=schema)
         result = session.execute(expired_sql).fetchone()[0]
         monitor.record_gauge(stat='reaper.expired_replicas', value=result)


### PR DESCRIPTION
These are the probes CMS is using which are not python3 compatible. The changes are dead simple except for one merely simple case. :-)