### PR TITLE
Update expired_dids for Rucio 1.27

### DIFF
--- a/common/check_expired_dids
+++ b/common/check_expired_dids
@@ -42,7 +42,7 @@ if __name__ == "__main__":
         result = get_count(query)
         # Possible check against a threshold. If result > max_value then sys.exit(CRITICAL)
 
-        monitor.record_gauge(stat='undertaker.expired_dids', value=result)
+        monitor.record_gauge('undertaker.expired_dids', value=result)
         Gauge('undertaker_expired_dids', '', registry=registry).set(result)
 
         if len(PROM_SERVERS):

--- a/common/check_expired_dids
+++ b/common/check_expired_dids
@@ -8,7 +8,7 @@
 # Authors:
 # - Vincent Garonne, <vincent.garonne@cern.ch>, 2013
 # - Thomas Beermann, <thomas.beermann@cern.ch>, 2019
-# - Eric Vaandering <ewv@fnal.gov>, 2020
+# - Eric Vaandering <ewv@fnal.gov>, 2020-2021
 
 """
 Probe to check the backlog of expired dids.


### PR DESCRIPTION
In Rucio 1.27 the first parameter is "name" not stat. This works for both