### PR TITLE
ATLAS: Do not restrict downtimes to GOCDB

### DIFF
--- a/atlas/check_site_status
+++ b/atlas/check_site_status
@@ -70,7 +70,7 @@ if __name__ == '__main__':
                 try:
                     if DATA[site][activity]['status']['value'] == 'OFF':
                         EXCLUDED_SITES[MAPPING[activity]].append(site)
-                        if DATA[site][activity]['status']['provider'] == 'DOWNTIME' and DATA[site][activity]['status']['reason'].find('https://goc.egi.eu/portal/index.php?Page_Type=Downtime') > -1:
+                        if DATA[site][activity]['status']['provider'] == 'DOWNTIME':
                             DOWNTIMES[site] = DATA[site][activity]['status']['reason']
                 except KeyError as error:
                     print(error)


### PR DESCRIPTION
OSG sites do not have a link to a GOCDB entry. This meant that declared
downtimes would not result in the SEs being banned in FTS. Consequently,
already submitted transfers would still be attempted.

Note that manual exclusion will still not be propagated to FTS. This is
something that can be reviewed in the future.