### PR TITLE
Common: Check_expired_locked_rules modernization. #127

### DIFF
--- a/common/check_expired_locked_rules
+++ b/common/check_expired_locked_rules
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright 2012-2024 CERN
+# Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,26 +12,22 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
-# Authors:
-# - Cedric Serfon, <cedric.serfon@cern.ch>, 2015
-# - Donata Mielaikaite, <donata.mielaikaite@cern.ch>, 2020
-# - Eric Vaandering, <ewv@fnal.gov>, 2020
-# - Maggie Voetberg <maggiev@fnal.gov>, 2024
 
 
-'''
+"""
 Probe to check the locked expired rules or datasets with locked rules
-'''
+"""
 
-from collections import defaultdict
 import datetime
 import sys
 import traceback
-from sqlalchemy import select, and_
-from sqlalchemy.sql import true, null
+from collections import defaultdict
+
+from sqlalchemy import and_, select
+from sqlalchemy.sql import null, true
 
 from rucio.db.sqla import models, session
+
 from utils.common import PrometheusPusher
 
 # Exit statuses
@@ -114,7 +110,7 @@ if __name__ == '__main__':
                     .labels(rse_expression=rse_expression)
                     .set(dids))
 
-        except:
+        except Exception:
             print(traceback.format_exc())
             sys.exit(UNKNOWN)
 

--- a/common/check_expired_locked_rules
+++ b/common/check_expired_locked_rules
@@ -18,31 +18,32 @@
 Probe to check the locked expired rules or datasets with locked rules
 """
 
-import datetime
 import sys
 import traceback
 from collections import defaultdict
+from datetime import datetime
 
 from sqlalchemy import and_, select
 from sqlalchemy.sql import null, true
 
-from rucio.db.sqla import models, session
+from rucio.db.sqla import models
+from rucio.db.sqla.session import get_session
 
 from utils.common import PrometheusPusher
 
 # Exit statuses
 OK, WARNING, CRITICAL, UNKNOWN = 0, 1, 2, 3
 
-if __name__ == '__main__':
+if __name__ == "__main__":
 
     status = OK
-    session = session.get_session()
+    session = get_session()
 
     # Select statement used for both metrics
     base_statement = select(
-        models.ReplicationRule,
-        models.DataIdentifier.name,
-        models.DataIdentifier.scope,
+        models.ReplicationRule.id,
+        models.ReplicationRule.name,
+        models.ReplicationRule.scope,
         models.ReplicationRule.rse_expression,
     )
 
@@ -60,7 +61,7 @@ if __name__ == '__main__':
             # Print rules for nagios monitoring
             print("Locked expired rules")
             for row in session.execute(statement):
-                print(row.rule_id, row.scope, row.name, row.rse_expression)
+                print(row.id, row.scope, row.name, row.rse_expression)
                 status = CRITICAL
                 # Keep track of the counts
                 rule_counts[row.rse_expression] += 1
@@ -98,11 +99,11 @@ if __name__ == '__main__':
 
             print("Datasets expired with locked rules")
             for row in session.execute(statement):
-                print(row.rule_id, row.scope, row.name, row.rse_expression)
+                print(row.id, row.scope, row.name, row.rse_expression)
                 status = CRITICAL
                 datasets_count[row.rse_expression] += 1
 
-            rule_counts["All"] = sum(rule_counts.values())
+            datasets_count["All"] = sum(datasets_count.values())
             for rse_expression, dids in datasets_count.items():
                 (manager.gauge(
                         "locked_expired_rules.dids.{rse_expression}",

--- a/common/check_expired_locked_rules
+++ b/common/check_expired_locked_rules
@@ -24,10 +24,12 @@
 Probe to check the locked expired rules or datasets with locked rules
 '''
 
+from collections import defaultdict
+import datetime
 import sys
 import traceback
 from sqlalchemy import select, and_
-from sqlalchemy.sql import functions
+from sqlalchemy.sql import true, null
 
 from rucio.db.sqla import models, session
 from utils.common import PrometheusPusher
@@ -39,31 +41,36 @@ if __name__ == '__main__':
 
     status = OK
     session = session.get_session()
-    with PrometheusPusher() as manager: 
-        try:            
-            statement = select(
-                models.ReplicationRule.id, 
-                models.ReplicationRule.scope, 
-                models.ReplicationRule.name, 
-                models.ReplicationRule.rse_expression
-            ).where(
+
+    # Select statement used for both metrics
+    base_statement = select(
+        models.ReplicationRule,
+        models.DataIdentifier.name,
+        models.DataIdentifier.scope,
+        models.ReplicationRule.rse_expression,
+    )
+
+    # Use prometheus pusher to send results to a remote service
+    with PrometheusPusher() as manager:
+        try:
+            statement = base_statement.where(
                 and_(
-                    models.ReplicationRule.locked == '1', 
-                    models.ReplicationRule.expires_at<functions.current_timestamp()
+                    models.ReplicationRule.locked == true(),
+                    models.ReplicationRule.expires_at < datetime.utcnow()  # see https://github.com/rucio/rucio/issues/6476
                 )
             )
-            query = session.execute(statement).scalars()
-            rule_counts = {"null":0}
+            rule_counts = defaultdict(int)
 
-            print('Locked expired rules')
-            for rule_id, scope, name, rse_expression in query: 
-                print(rule_id, scope, name, rse_expression)
+            # Print rules for nagios monitoring
+            print("Locked expired rules")
+            for row in session.execute(statement):
+                print(row.rule_id, row.scope, row.name, row.rse_expression)
                 status = CRITICAL
+                # Keep track of the counts
+                rule_counts[row.rse_expression] += 1
 
-                if rse_expression in rule_counts.keys(): 
-                    rule_counts[rse_expression] += 1 
-                else: 
-                    rule_counts[rse_expression] = 1
+            # Add a summary entry so when there are no result from the query there is metric continuity
+            rule_counts["All"] = sum(rule_counts.values())
 
             for rse_expression, count in rule_counts.items():
                 manager.gauge('locked_expired_rules.{rse_expression}',
@@ -77,35 +84,26 @@ if __name__ == '__main__':
             sys.exit(UNKNOWN)
 
         try:
-            statement = select(
-                    models.ReplicationRule.id, 
-                    models.DataIdentifier.name,
-                    models.DataIdentifier.scope,
-                    models.ReplicationRule.rse_expression
-                ).join(
-                    models.DataIdentifier, 
-                    (models.ReplicationRule.scope == models.DataIdentifier.scope) & (models.ReplicationRule.name == models.DataIdentifier.name)
-                ).where(
-                    and_(
-                        models.ReplicationRule.locked == True, 
-                        models.DataIdentifier.expired_at != None, 
-                        models.DataIdentifier.expired_at < functions.current_timestamp()
-                    )
+            statement = base_statement.join(
+                models.DataIdentifier,
+                and_(
+                    models.ReplicationRule.scope == models.DataIdentifier.scope,
+                    models.ReplicationRule.name == models.DataIdentifier.name,
+                ),
+            ).where(
+                and_(
+                    models.ReplicationRule.locked == true(),
+                    models.DataIdentifier.expired_at != null(),
+                    models.DataIdentifier.expired_at < datetime.utcnow()  # see https://github.com/rucio/rucio/issues/6476
                 )
+            )
+            datasets_count = defaultdict(int)
 
-            query = session.execute(statement).scalars()
-            datasets_count = {"null":0}
-
-            print('Datasets expired with locked rules')
-            for rule_id, scope, name, rse_expression in query: 
-                print(rule_id, scope, name, rse_expression)
+            print("Datasets expired with locked rules")
+            for row in session.execute(statement):
+                print(row.rule_id, row.scope, row.name, row.rse_expression)
                 status = CRITICAL
-
-                if rse_expression in datasets_count.keys(): 
-                    datasets_count[rse_expression] += 1 
-                else: 
-                    datasets_count[rse_expression] = 1
-
+                datasets_count[row.rse_expression] += 1
 
             for rse_expression, dids in datasets_count.items():
                 manager.gauge('locked_expired_rules.dids.{rse_expression}',

--- a/common/check_expired_locked_rules
+++ b/common/check_expired_locked_rules
@@ -1,56 +1,121 @@
-#!/usr/bin/env python
-# Copyright European Organization for Nuclear Research (CERN) 2013
+#!/usr/bin/env python3
+# Copyright 2012-2024 CERN
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
-# You may not use this file except in compliance with the License.
-# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 #
 # Authors:
 # - Cedric Serfon, <cedric.serfon@cern.ch>, 2015
+# - Donata Mielaikaite, <donata.mielaikaite@cern.ch>, 2020
+# - Eric Vaandering, <ewv@fnal.gov>, 2020
+# - Maggie Voetberg <maggiev@fnal.gov>, 2024
+
 
 '''
 Probe to check the locked expired rules or datasets with locked rules
 '''
 
 import sys
-from rucio.db.sqla.session import get_session
+import traceback
+from sqlalchemy import select, and_
+from sqlalchemy.sql import functions
+
+from rucio.db.sqla import models, session
+from utils.common import PrometheusPusher
 
 # Exit statuses
 OK, WARNING, CRITICAL, UNKNOWN = 0, 1, 2, 3
 
+if __name__ == '__main__':
 
-def main():
-    '''
-    Probe to check the locked expired rules or datasets with locked rules
-    '''
     status = OK
-    session = get_session()
-    try:
-        query = "select rawtohex(id), scope, name, rse_expression from atlas_rucio.rules where locked=1 and expires_at<sys_extract_utc(localtimestamp)"
-        print 'Locked expired rules'
-        for row in session.execute(query):
-            status = CRITICAL
-            print row[0], row[1], row[2]
-    except Exception as error:
-        print error
-        status = UNKNOWN
-        sys.exit(status)
-    try:
-        query = """select rawtohex(c.id), c.scope, c.name, c.rse_expression from atlas_rucio.rules c,
-                   (select a.scope, a.name from atlas_rucio.dids a
-                   where a.expired_at is not null and a.expired_at < sys_extract_utc(localtimestamp)
-                   and exists (select 1 from atlas_rucio.rules b where a.scope=b.scope and a.name=b.name and locked=1)) d
-                   where c.scope=d.scope and c.name=d.name and locked=1"""
-        print 'Datasets expired with locked rules'
-        for row in session.execute(query):
-            status = CRITICAL
-            print row[0], row[1], row[2], row[3]
-    except Exception as error:
-        print error
-        status = UNKNOWN
-        sys.exit(status)
+    session = session.get_session()
+    with PrometheusPusher() as manager: 
+        try:            
+            statement = select(
+                models.ReplicationRule.id, 
+                models.ReplicationRule.scope, 
+                models.ReplicationRule.name, 
+                models.ReplicationRule.rse_expression
+            ).where(
+                and_(
+                    models.ReplicationRule.locked == '1', 
+                    models.ReplicationRule.expires_at<functions.current_timestamp()
+                )
+            )
+            query = session.execute(statement).scalars()
+            rule_counts = {"null":0}
+
+            print('Locked expired rules')
+            for rule_id, scope, name, rse_expression in query: 
+                print(rule_id, scope, name, rse_expression)
+                status = CRITICAL
+
+                if rse_expression in rule_counts.keys(): 
+                    rule_counts[rse_expression] += 1 
+                else: 
+                    rule_counts[rse_expression] = 1
+
+            for rse_expression, count in rule_counts.items():
+                manager.gauge('locked_expired_rules.{rse_expression}',
+                        documentation='Number of rules that are locked and expired, by RSE.'
+                    ).labels(
+                        rse_expression=rse_expression
+                    ).set(count)
+
+        except Exception as error:
+            print(traceback.format_exc())
+            sys.exit(UNKNOWN)
+
+        try:
+            statement = select(
+                    models.ReplicationRule.id, 
+                    models.DataIdentifier.name,
+                    models.DataIdentifier.scope,
+                    models.ReplicationRule.rse_expression
+                ).join(
+                    models.DataIdentifier, 
+                    (models.ReplicationRule.scope == models.DataIdentifier.scope) & (models.ReplicationRule.name == models.DataIdentifier.name)
+                ).where(
+                    and_(
+                        models.ReplicationRule.locked == True, 
+                        models.DataIdentifier.expired_at != None, 
+                        models.DataIdentifier.expired_at < functions.current_timestamp()
+                    )
+                )
+
+            query = session.execute(statement).scalars()
+            datasets_count = {"null":0}
+
+            print('Datasets expired with locked rules')
+            for rule_id, scope, name, rse_expression in query: 
+                print(rule_id, scope, name, rse_expression)
+                status = CRITICAL
+
+                if rse_expression in datasets_count.keys(): 
+                    datasets_count[rse_expression] += 1 
+                else: 
+                    datasets_count[rse_expression] = 1
+
+
+            for rse_expression, dids in datasets_count.items():
+                manager.gauge('locked_expired_rules.dids.{rse_expression}',
+                        documentation='Number of expired DIDs with locked rules, by RSE'
+                    ).labels(
+                        rse_expression=rse_expression
+                    ).set(dids)
+
+        except:
+            print(traceback.format_exc())
+            sys.exit(UNKNOWN)
+
     sys.exit(status)
-
-
-if __name__ == "__main__":
-    main()

--- a/common/check_expired_locked_rules
+++ b/common/check_expired_locked_rules
@@ -72,12 +72,13 @@ if __name__ == '__main__':
             # Add a summary entry so when there are no result from the query there is metric continuity
             rule_counts["All"] = sum(rule_counts.values())
 
+            # Send to Prometheus pusher
             for rse_expression, count in rule_counts.items():
-                manager.gauge('locked_expired_rules.{rse_expression}',
-                        documentation='Number of rules that are locked and expired, by RSE.'
-                    ).labels(
-                        rse_expression=rse_expression
-                    ).set(count)
+                (manager.gauge(
+                        "locked_expired_rules.{rse_expression}",
+                        documentation="Number of rules that are locked and expired, by RSE expression.")
+                    .labels(rse_expression=rse_expression)
+                    .set(count))
 
         except Exception as error:
             print(traceback.format_exc())
@@ -105,12 +106,13 @@ if __name__ == '__main__':
                 status = CRITICAL
                 datasets_count[row.rse_expression] += 1
 
+            rule_counts["All"] = sum(rule_counts.values())
             for rse_expression, dids in datasets_count.items():
-                manager.gauge('locked_expired_rules.dids.{rse_expression}',
-                        documentation='Number of expired DIDs with locked rules, by RSE'
-                    ).labels(
-                        rse_expression=rse_expression
-                    ).set(dids)
+                (manager.gauge(
+                        "locked_expired_rules.dids.{rse_expression}",
+                        documentation="Number of expired DIDs with locked rules, by RSE expression")
+                    .labels(rse_expression=rse_expression)
+                    .set(dids))
 
         except:
             print(traceback.format_exc())


### PR DESCRIPTION
Changes:
	- Change text-only queries to poll the data model (rucio.db.sqla.models)
	- Push results to a remote (See documentation of probes for descriptions). Names: locked_expired_rules.(rse), locked_expired_rules.dids.(rse), locked_expired_rules.rules_for_dids.(rse)
       - included a check that still updates the probe even if the result is 0, to ensure the dashboards reading the probe always have data. 

Sqla update uses pr #46 as a basis. 

cc: @ericvaandering 

