### PR TITLE
Add/update headers for all active files, add pre-commit 

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,22 @@
+repos:
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v2.3.0
+  hooks:
+  - id: end-of-file-fixer
+  - id: trailing-whitespace
+- repo: https://github.com/PyCQA/flake8
+  rev: 4.0.1
+  hooks:
+  - id: flake8
+- repo: local
+  hooks:
+  - id: add-header
+    name: Run `add_header` script
+    description: Run the `add_header` script to verify the file headers
+    entry: ./add_header.sh
+    language: system
+- repo: https://github.com/astral-sh/ruff-pre-commit
+  rev: v0.3.3
+  hooks:
+    - id: ruff
+      args: [ --fix ]

--- a/add_header.sh
+++ b/add_header.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+curl 'https://raw.githubusercontent.com/rucio/rucio/master/tools/add_header' > add_header
+python3 add_header $(find atlas/* -type f ) $(find cms/* -type f ) $(find common/* -type f -maxdepth 2)

--- a/atlas/check_ami
+++ b/atlas/check_ami
@@ -1,15 +1,20 @@
 #!/usr/bin/env python
+# Copyright European Organization for Nuclear Research (CERN) since 2012
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+  
 '''
-  Copyright European Organization for Nuclear Research (CERN) 2013
-
-  Licensed under the Apache License, Version 2.0 (the "License");
-  You may not use this file except in compliance with the License.
-  You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
-
-  Authors:
-  - Vincent Garonne, <vincent.garonne@cern.ch>, 2015
-  - Cedric Serfon, <cedric.serfon@cern.ch>, 2018
-
   Probe to check datatype, project and convention from AMI
 '''
 

--- a/atlas/check_ami
+++ b/atlas/check_ami
@@ -21,8 +21,8 @@
 import sys
 import traceback
 
-from rucio.db.sqla.session import get_session
 from rucio.core.scope import add_scope
+from rucio.db.sqla.session import get_session
 
 # Exit statuses
 OK, WARNING, CRITICAL, UNKNOWN = 0, 1, 2, 3

--- a/atlas/check_disabled_rses
+++ b/atlas/check_disabled_rses
@@ -14,14 +14,14 @@
 # limitations under the License.
 
 import json
-import requests
 import sys
 import traceback
+
+import requests
 
 from rucio.client import Client
 from rucio.common.config import config_get
 from rucio.common.exception import RSENotFound
-
 
 UNKNOWN = 3
 CRITICAL = 2

--- a/atlas/check_disabled_rses
+++ b/atlas/check_disabled_rses
@@ -1,13 +1,17 @@
 #!/usr/bin/env python
-# Copyright European Organization for Nuclear Research (CERN)
+# Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
-# You may not use this file except in compliance with the License.
+# you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# http://www.apache.org/licenses/LICENSE-2.0
 #
-# Authors:
-# - Cedric Serfon, <cedric.serfon@cern.ch>, 2015-2016
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 import json
 import requests

--- a/atlas/check_injecting_rules
+++ b/atlas/check_injecting_rules
@@ -28,8 +28,6 @@ from rucio.db.sqla import models
 from rucio.db.sqla.constants import RuleState
 from rucio.db.sqla.session import get_session
 
-from utils import probe_metrics
-
 # Exit statuses
 OK, WARNING, CRITICAL, UNKNOWN = 0, 1, 2, 3
 

--- a/atlas/check_lost_files
+++ b/atlas/check_lost_files
@@ -13,22 +13,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
-import sys
-import smtplib
-import time
-import requests
 import calendar
-from email.mime.text import MIMEText
-from email.MIMEMultipart import MIMEMultipart
-from email.MIMEBase import MIMEBase
-from email import Encoders
 import mimetypes  # to guess mimetype
+import os
+import smtplib
+import sys
+import time
 # from rucio.common.config import config_get
-from datetime import datetime
-from datetime import date
+from datetime import date, datetime
+from email import Encoders
+from email.mime.text import MIMEText
+from email.MIMEBase import MIMEBase
+from email.MIMEMultipart import MIMEMultipart
+
 # pandas to prepare statistics  RSE:scope:count, may be used to re-implement all the script
 import pandas as pd
+import requests
 
 from rucio.db.sqla.session import get_session
 

--- a/atlas/check_lost_files
+++ b/atlas/check_lost_files
@@ -1,13 +1,17 @@
 #!/usr/bin/env python
-# Copyright European Organization for Nuclear Research (CERN) 2015
+# Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
-# You may not use this file except in compliance with the License.
-# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 #
-# Authors:
-# - Tomas Javurek, Cedric Serfon, 2015
-# - Alexander Bogdanchikov, 2019-2020
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 import os
 import sys

--- a/atlas/check_map_voms_roles
+++ b/atlas/check_map_voms_roles
@@ -16,11 +16,11 @@
 import os
 import sys
 
+from VOMSAdmin.VOMSCommands import VOMSAdminProxy
+
 from rucio.client import Client
 from rucio.common.config import config_get
 from rucio.common.exception import Duplicate
-
-from VOMSAdmin.VOMSCommands import VOMSAdminProxy
 
 UNKNOWN = 3
 CRITICAL = 2

--- a/atlas/check_map_voms_roles
+++ b/atlas/check_map_voms_roles
@@ -1,18 +1,17 @@
 #!/usr/bin/env python
-"""
- Copyright European Organization for Nuclear Research (CERN)
-
- Licensed under the Apache License, Version 2.0 (the "License");
- You may not use this file except in compliance with the License.
- You may obtain a copy of the License at
-                       http://www.apache.org/licenses/LICENSE-2.0
-
- Authors:
- - Cedric Serfon, <cedric.serfon@cern.ch>, 2014, 2017
- - Joaquin Bogado, <joaquin.bogado@cern.ch>, 2014
- - Mario Lassnig, <mario.lassnig@cern.ch>, 2015
- - Dimitrios Christidis, <dimitrios.christidis@cern.ch>, 2019-2020
-"""
+# Copyright European Organization for Nuclear Research (CERN) since 2012
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 import os
 import sys

--- a/atlas/check_quotas
+++ b/atlas/check_quotas
@@ -1,19 +1,19 @@
 #!/usr/bin/env python3
+# Copyright European Organization for Nuclear Research (CERN) since 2012
 #
-# Copyright European Organization for Nuclear Research (CERN)
-
 # Licensed under the Apache License, Version 2.0 (the "License");
-# You may not use this file except in compliance with the License.
+# you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-#                       http://www.apache.org/licenses/LICENSE-2.0
 #
-# Authors:
-# - David Cameron, <david.cameron@cern.ch>, 2015
-# - Vincent Garonne, <vincent.garonne@cern.ch>, 2015
-# - Cedric Serfon, <cedric.serfon@cern.ch>, 2016-2019
-# - Dimitrios Christidis, <dimitrios.christidis@cern.ch>, 2021
+#    http://www.apache.org/licenses/LICENSE-2.0
 #
-#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
 # Set quotas for physgroups
 # Set quotas for users on their country's localgroupdisk
 # Set quotas for all users on scratchdisk

--- a/atlas/check_quotas
+++ b/atlas/check_quotas
@@ -19,19 +19,20 @@
 # Set quotas for all users on scratchdisk
 
 from __future__ import print_function
+
 import json
 import sys
 
 import requests
 
-from rucio.api.rse import get_rse, parse_rse_expression, get_rse_usage, list_rse_attributes
 from rucio.api.account import list_accounts
 from rucio.api.account_limit import set_local_account_limit
 from rucio.api.config import get
-from rucio.db.sqla.session import get_session
+from rucio.api.rse import (get_rse, get_rse_usage, list_rse_attributes,
+                           parse_rse_expression)
 from rucio.common.config import config_get
-from rucio.common.exception import RucioException, RSENotFound, AccountNotFound
-
+from rucio.common.exception import AccountNotFound, RSENotFound, RucioException
+from rucio.db.sqla.session import get_session
 
 UNKNOWN = 3
 CRITICAL = 2

--- a/atlas/check_rse_attributes
+++ b/atlas/check_rse_attributes
@@ -21,15 +21,14 @@ import json
 import sys
 import traceback
 
-
 import requests
 
-from rucio.db.sqla.session import get_session
-from rucio.common.exception import RucioException, RSENotFound
 from rucio.common.config import config_get
-from rucio.core.rse import add_rse_attribute, get_rses_with_attribute, del_rse_attribute, get_rse_usage, get_rse
+from rucio.common.exception import RSENotFound, RucioException
+from rucio.core.rse import (add_rse_attribute, del_rse_attribute, get_rse,
+                            get_rse_usage, get_rses_with_attribute)
 from rucio.core.rse_expression_parser import parse_expression
-
+from rucio.db.sqla.session import get_session
 
 UNKNOWN = 3
 CRITICAL = 2

--- a/atlas/check_rse_attributes
+++ b/atlas/check_rse_attributes
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright 2012-2019 CERN for the benefit of the ATLAS collaboration.
+# Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,15 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
-# Authors:
-# - Vincent Garonne <vincent.garonne@cern.ch>, 2013-2014
-# - David Cameron <david.cameron@cern.ch>, 2014-2015,2020
-# - Tomas Kouba <tomas.kouba@cern.ch>, 2014
-# - Cedric Serfon <cedric.serfon@cern.ch>, 2016-2019
-# - Dimitrios Christidis <dimitrios.christidis@cern.ch>, 2019
-# - Mario Lassnig <mario.lassnig@cern.ch>, 2019
-#
+
 # PY3K COMPATIBLE
 
 from __future__ import print_function

--- a/atlas/check_rules
+++ b/atlas/check_rules
@@ -1,12 +1,17 @@
 #!/usr/bin/env python
-# Copyright European Organization for Nuclear Research (CERN) 2013
+# Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
-# You may not use this file except in compliance with the License.
-# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 #
-# Authors:
-# - Wen Guan, <wguan@cern.ch>, 2014
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 '''
 Probe to check rules.

--- a/atlas/check_set_rse_space_limits
+++ b/atlas/check_set_rse_space_limits
@@ -34,8 +34,9 @@
 
 import json
 import sys
-from urlparse import urlparse
+
 import requests
+from urlparse import urlparse
 
 # Try to use server environment (direct database access). If that fails use
 # client.

--- a/atlas/check_set_rse_space_limits
+++ b/atlas/check_set_rse_space_limits
@@ -1,16 +1,19 @@
 #!/usr/bin/env python
+# Copyright European Organization for Nuclear Research (CERN) since 2012
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """
- Copyright European Organization for Nuclear Research (CERN) 2014
-
- Licensed under the Apache License, Version 2.0 (the "License");
- You may not use this file except in compliance with the License.
- You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
-
- Authors:
- - David Cameron, <david.cameron@cern.ch>, 2014-2016
- - Mario Lassnig, <mario.lassnig@cern.ch>, 2015
- - Cedric Serfon, <cedric.serfon@cern.ch>, 2017
-
  Sets the minimum free space on RSEs according to the policy, which is set in
  the configuration table of Rucio server. A relative and absolute limit are
  set for the relevant endpoints, for example:

--- a/atlas/check_site_status
+++ b/atlas/check_site_status
@@ -19,10 +19,9 @@ import sys
 
 import requests
 
+from rucio.api.rse import get_rse_protocols, list_rses, update_rse
 from rucio.common.config import config_get
-from rucio.api.rse import list_rses, update_rse, get_rse_protocols
 from rucio.transfertool.fts3 import FTS3Transfertool
-
 
 UNKNOWN = 3
 CRITICAL = 2

--- a/atlas/check_site_status
+++ b/atlas/check_site_status
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright 2012-2020 CERN for the benefit of the ATLAS collaboration.
+# Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,11 +12,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
-# Authors:
-# - Cedric Serfon <cedric.serfon@cern.ch>, 2014-2022
-# - Mario Lassnig <mario.lassnig@cern.ch>, 2020
-#
 
 import json
 import os

--- a/atlas/check_storage_space
+++ b/atlas/check_storage_space
@@ -19,10 +19,11 @@ import sys
 
 import gfal2
 
+from rucio.api.rse import (get_rse, list_rse_attributes, list_rses,
+                           set_rse_usage)
 from rucio.common.config import config_get
 from rucio.common.exception import RSEProtocolNotSupported
 from rucio.rse import rsemanager as rsemgr
-from rucio.api.rse import list_rses, list_rse_attributes, get_rse, set_rse_usage
 
 OK, WARNING, CRITICAL, UNKNOWN = 0, 1, 2, 3
 

--- a/atlas/check_storage_space
+++ b/atlas/check_storage_space
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright 2012-2020 CERN for the benefit of the ATLAS collaboration.
+# Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,14 +12,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
-# Authors:
-# - Wen Guan <wen.guan@cern.ch>, 2014
-# - Sylvain Blunier <sylvain.blunier@cern.ch>, 2016
-# - Tomas Javurek <Tomas.Javurek@cern.ch>, 2016
-# - Cedric Serfon <cedric.serfon@cern.ch>, 2015-2017
-# - Dimitrios Christidis <dimitrios.christidis@cern.ch>, 2019
-# - Mario Lassnig <mario.lassnig@cern.ch>, 2020
 
 import json
 import os

--- a/atlas/check_stresstest_dids_requests_replicas_daily
+++ b/atlas/check_stresstest_dids_requests_replicas_daily
@@ -1,12 +1,17 @@
 #!/usr/bin/env python
-# Copyright European Organization for Nuclear Research (CERN) 2013
+# Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
-# You may not use this file except in compliance with the License.
-# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 #
-# Authors:
-# - Wen Guan, <wguan@cern.ch>, 2014
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 '''
 Probe to check dids, requests and replicas by daily.

--- a/atlas/check_stresstest_dids_requests_replicas_hourly
+++ b/atlas/check_stresstest_dids_requests_replicas_hourly
@@ -1,12 +1,17 @@
 #!/usr/bin/env python
-# Copyright European Organization for Nuclear Research (CERN) 2013
+# Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
-# You may not use this file except in compliance with the License.
-# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 #
-# Authors:
-# - Wen Guan, <wguan@cern.ch>, 2014
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 '''
 Probe to check dids, requests and replicas by hourly.

--- a/atlas/check_sync_rses_with_cric
+++ b/atlas/check_sync_rses_with_cric
@@ -1,17 +1,17 @@
 #!/usr/bin/env python3
-# Copyright European Organization for Nuclear Research (CERN)
+# Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
-# You may not use this file except in compliance with the License.
+# you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# http://www.apache.org/licenses/LICENSE-2.0
 #
-# Authors:
-# - Vincent Garonne, <vincent.garonne@cern.ch>, 2013-2014
-# - Mario Lassnig, <mario.lassnig@cern.ch>, 2014-2022
-# - Cedric Serfon, <cedric.serfon@cern.ch>, 2014-2018
-# - David Cameron, <david.cameron@cern.ch>, 2015
-# - Dimitrios Christidis, <dimitrios.christidis@cern.ch>, 2021
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 import json
 import os.path

--- a/atlas/check_sync_rses_with_cric
+++ b/atlas/check_sync_rses_with_cric
@@ -23,11 +23,13 @@ import requests
 
 from rucio.api.account import list_accounts
 from rucio.api.account_limit import set_local_account_limit
-from rucio.api.rse import get_rse_protocols, add_protocol, add_rse, update_protocols
+from rucio.api.rse import (add_protocol, add_rse, get_rse_protocols,
+                           update_protocols)
 from rucio.common.config import config_get
-from rucio.common.exception import Duplicate, RSEProtocolPriorityError, RSEProtocolNotSupported, RSENotFound
+from rucio.common.exception import (Duplicate, RSENotFound,
+                                    RSEProtocolNotSupported,
+                                    RSEProtocolPriorityError)
 from rucio.db.sqla.constants import RSEType
-
 
 UNKNOWN = 3
 CRITICAL = 2

--- a/atlas/check_voms
+++ b/atlas/check_voms
@@ -22,14 +22,13 @@ import sys
 import time
 
 import ldap  # pylint: disable=import-error
+from VOMSAdmin.VOMSCommands import \
+    VOMSAdminProxy  # pylint: disable=import-error
 
-from rucio.db.sqla.session import get_session
 from rucio.client import Client
 from rucio.common.config import config_get
 from rucio.common.exception import Duplicate
-
-from VOMSAdmin.VOMSCommands import VOMSAdminProxy  # pylint: disable=import-error
-
+from rucio.db.sqla.session import get_session
 
 UNKNOWN = 3
 CRITICAL = 2

--- a/atlas/check_voms
+++ b/atlas/check_voms
@@ -1,17 +1,18 @@
 #!/usr/bin/env python
-# Copyright European Organization for Nuclear Research (CERN)
+# Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
-# You may not use this file except in compliance with the License.
+# you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-#                       http://www.apache.org/licenses/LICENSE-2.0
 #
-# Authors:
-# - Vincent Garonne, <vincent.garonne@cern.ch>, 2012-2013
-# - Cedric Serfon, <cedric.serfon@cern.ch>, 2014-2018
-# - David Cameron, <david.cameron@cern.ch>, 2015
-# - Dimitrios Christidis, <dimitrios.christidis@cern.ch>, 2019
+#    http://www.apache.org/licenses/LICENSE-2.0
 #
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # PY3K COMPATIBLE
 
 from __future__ import print_function

--- a/atlas/check_voms_admin
+++ b/atlas/check_voms_admin
@@ -1,15 +1,18 @@
 #!/usr/bin/env python
-# Copyright European Organization for Nuclear Research (CERN)
+# Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
-# You may not use this file except in compliance with the License.
+# you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-#                       http://www.apache.org/licenses/LICENSE-2.0
 #
-# Authors:
-# - David Cameron, <david.cameron@cern.ch>, 2015
-# - Cedric Serfon, <cedric.serfon@cern.ch>, 2016
+#    http://www.apache.org/licenses/LICENSE-2.0
 #
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # Get country groups from VOMS, get DNs with production role,
 # map to Rucio account and set country-<country>: admin
 # Get all DNs in country and set country-<country>: user

--- a/atlas/check_voms_admin
+++ b/atlas/check_voms_admin
@@ -21,15 +21,16 @@
 
 import os
 import re
-import sys
 import shlex
 import subprocess
-
-from rucio.api.account import list_accounts, add_account_attribute, del_account_attribute, list_account_attributes
-from rucio.common.config import config_get
-from rucio.common.exception import RucioException, Duplicate, AccountNotFound
+import sys
 
 from VOMSAdmin.VOMSCommands import VOMSAdminProxy
+
+from rucio.api.account import (add_account_attribute, del_account_attribute,
+                               list_account_attributes, list_accounts)
+from rucio.common.config import config_get
+from rucio.common.exception import AccountNotFound, Duplicate, RucioException
 
 UNKNOWN = 3
 CRITICAL = 2

--- a/atlas/check_xcache
+++ b/atlas/check_xcache
@@ -30,14 +30,12 @@ except ImportError:
     # Python 3
     from urllib.parse import urlparse
 
-from rucio.db.sqla.session import get_session
 from rucio.common.config import config_get
 from rucio.common.exception import RucioException
-
-from rucio.core.config import set as core_set
 from rucio.core.config import items as core_items
 from rucio.core.config import remove_option as core_del
-
+from rucio.core.config import set as core_set
+from rucio.db.sqla.session import get_session
 
 UNKNOWN = 3
 CRITICAL = 2

--- a/atlas/check_xcache
+++ b/atlas/check_xcache
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright 2012-2019 CERN for the benefit of the ATLAS collaboration.
+# Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,11 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
-# Authors:
-# - Mario Lassnig, <mario.lassnig@cern.ch>, 2012-2019
-# - Dimitrios Christidis, <dimitrios.christidis@cern.ch>, 2020
-#
+
 # PY3K COMPATIBLE
 
 from __future__ import print_function

--- a/cms/check_expected_total_number_of_files_per_rse
+++ b/cms/check_expected_total_number_of_files_per_rse
@@ -1,13 +1,17 @@
 #!/usr/bin/env python3
-# Copyright European Organization for Nuclear Research (CERN) 2013
+# Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
-# You may not use this file except in compliance with the License.
-# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 #
-# Authors:
-# - Donata Mielaikaite, <donata.mielaikaite@cern.ch>, 2020
-# - Eric Vaandering, <ewv@fnal.gov>, 2022
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 """
 Probe to check the number of expected files per rse.

--- a/cms/check_expiring_rules_per_rse
+++ b/cms/check_expiring_rules_per_rse
@@ -1,13 +1,17 @@
 #!/usr/bin/env python3
-# Copyright European Organization for Nuclear Research (CERN) 2013
+# Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
-# You may not use this file except in compliance with the License.
-# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 #
-# Authors:
-# - Donata Mielaikaite, <donata.mielaikaite@cern.ch>, 2020
-# - Eric Vaandering, <ewv@fnal.gov>, 2022
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 """
 Probe to check the number of expiring rules.

--- a/cms/check_rse_files_rules
+++ b/cms/check_rse_files_rules
@@ -20,11 +20,11 @@ Probe to check the number of expected files per rse.
 import sys
 import traceback
 
-from rucio.db.sqla import models
-from rucio.db.sqla.constants import RequestType
-from rucio.db.sqla.constants import RuleState
-from rucio.db.sqla.session import get_session
 from sqlalchemy import func
+
+from rucio.db.sqla import models
+from rucio.db.sqla.constants import RequestType, RuleState
+from rucio.db.sqla.session import get_session
 
 from utils import common
 

--- a/cms/check_rse_files_rules
+++ b/cms/check_rse_files_rules
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright 2012-2020 CERN
+# Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,10 +12,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
-# Authors:
-# - Donata Mielaikaite, <donata.mielaikaite@cern.ch>, 2020
-# - Fernando Garzon, <oscar.fernando.garzon.miguez@cern.ch>, 2020
 
 """
 Probe to check the number of expected files per rse.

--- a/cms/check_rule_counts
+++ b/cms/check_rule_counts
@@ -24,12 +24,13 @@ import sys
 import traceback
 
 from prometheus_client import CollectorRegistry, Gauge, push_to_gateway
+from sqlalchemy import func
+
 from rucio.common.config import config_get
 from rucio.db.sqla import models
-from rucio.db.sqla.constants import (RuleState)
+from rucio.db.sqla.constants import RuleState
 from rucio.db.sqla.session import get_session
 from rucio.db.sqla.util import get_count
-from sqlalchemy import func
 
 from utils import common
 

--- a/cms/check_rule_counts
+++ b/cms/check_rule_counts
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright 2012-2024 CERN
+# Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,12 +12,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
-# Authors:
-# - Donata Mielaikaite, <donata.mielaikaite@cern.ch>, 2020
-# - Eric Vaandering, <ewv@fnal.gov>, 2021
-# - Fernando Garzon, ogarzonm@cern.ch, 2022
-# - Hasan Ozturk, haozturk AT cern DOT ch, 2024
 
 
 """
@@ -71,7 +65,7 @@ if __name__ == '__main__':
             for state, num in result:
                 manager.gauge(name='rule_count_per_state.{state}',
                               documentation='Number of rules in a given state').labels(state=str(state.name)).set(num)
-            
+
 
             # Rule count per state and activity
             results = (session.query(models.ReplicationRule.state, models.ReplicationRule.activity, func.count(models.ReplicationRule.state))
@@ -83,8 +77,8 @@ if __name__ == '__main__':
                 manager.gauge(name='rule_count_per_state_and_activity.{state}.{activity}',
                               documentation='Number of rules in a given state and activity').labels(state=result[0].name, activity=result[1]).set(result[2])
 
-            
-            # Lock count per state (STUCK and REPLICATING) and activity           
+
+            # Lock count per state (STUCK and REPLICATING) and activity
             results = (session.query(models.ReplicationRule.activity,
                                     func.sum(models.ReplicationRule.locks_stuck_cnt),
                                     func.sum(models.ReplicationRule.locks_replicating_cnt))
@@ -108,7 +102,7 @@ if __name__ == '__main__':
                             .filter(models.ReplicationRule.state == stateDB)
                             .filter(models.ReplicationRule.created_at <= age))
                     result = query.scalar() or 0
-                
+
                     manager.gauge(name='rule_count_per_state_and_date.{state}.{older_than_days}',
                                   documentation='Rule count per state and date').labels(state=stateName, older_than_days= nDays ).set(result)
 

--- a/cms/check_rules_states_by_account
+++ b/cms/check_rules_states_by_account
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright 2012-2024 CERN
+# Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,10 +12,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
-# Authors:
-# - Fernando Garzon, <oscar.fernando.garzon.miguez@cern.ch>, 2021
-# - Maggie Voetberg, <maggiev@fnal.gov>, 2024
 
 """
 Probe that counts the number of stuck, replicating rules and waiting for approval rules, clasiffied by account.

--- a/cms/check_rules_states_by_account
+++ b/cms/check_rules_states_by_account
@@ -20,11 +20,12 @@ Probe that counts the number of stuck, replicating rules and waiting for approva
 import sys
 import traceback
 
+from sqlalchemy import func
+
 from rucio.common.types import InternalAccount
 from rucio.db.sqla import models
 from rucio.db.sqla.constants import RuleState
 from rucio.db.sqla.session import get_session
-from sqlalchemy import func
 
 from utils import common
 

--- a/cms/check_unlocked_replicas_per_rse
+++ b/cms/check_unlocked_replicas_per_rse
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright 2012-2020 CERN
+# Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,13 +12,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
-# Authors:
-# - Vincent Garonne, <vincent.garonne@cern.ch>, 2013
-# - Thomas Beermann, <thomas.beermann@cern.ch>, 2019
-# - Fernando Garzon, <oscar.fernando.garzon.miguez@cern.ch>, 2020
-# - Donata Mielaikaite, <donata.mielaikaite@cern.ch>, 2020
-# - Eric Vaandering, <ewv@fnal.gov>, 2021
 
 
 """

--- a/cms/check_unlocked_replicas_per_rse
+++ b/cms/check_unlocked_replicas_per_rse
@@ -19,11 +19,12 @@ Probe to check the backlog of unlocked replicas per RSE.
 """
 
 import sys
-from datetime import (datetime, timedelta)
+from datetime import datetime, timedelta
+
+from sqlalchemy import func
 
 from rucio.db.sqla import models
 from rucio.db.sqla.session import get_session
-from sqlalchemy import func
 
 from utils import common
 

--- a/cms/check_used_space
+++ b/cms/check_used_space
@@ -20,7 +20,8 @@ Probe to check used space.
 import sys
 import traceback
 
-from rucio.core.rse import list_rses, get_rse_usage, list_rse_attributes, get_rse_limits
+from rucio.core.rse import (get_rse_limits, get_rse_usage, list_rse_attributes,
+                            list_rses)
 from rucio.db.sqla import models
 from rucio.db.sqla.session import get_session
 

--- a/cms/check_used_space
+++ b/cms/check_used_space
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright 2012-2020 CERN
+# Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,12 +12,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
-# Authors:
-# - Donata Mielaikaite, <donata.mielaikaite@cern.ch>, 2020
-# - Fernando Garzon, <oscar.fernando.garzon.miguez@cern.ch>, 2020
-# - Eric Vaandering, <ewv@fnal.gov>, 2021
-# - Panos Paparrigopoulos, <panos.paparrigopoulos@cern.ch>, 2024
 
 """
 Probe to check used space.
@@ -54,7 +48,7 @@ if __name__ == '__main__':
                 prom_labels = {'rse': rse['rse'], 'country': country, 'rse_type': rse_type, 'source': ''}
                 label_names = ['rse', 'country', 'rse_type', 'source']
                 for usage in sources:
-                    
+
                     # Calculate free rucio space of RSE and push it
                     if usage['source'] == 'rucio':
                         source = 'rucio_free_space'
@@ -70,7 +64,7 @@ if __name__ == '__main__':
                     # Calculate total free space of RSE (static-rucio) and push it
                     if usage['source'] == 'static':
                         static_used = usage['used']
-                    
+
                     if rucio_used and static_used:
                         source = 'free_space'
                         prom_labels['source'] = source
@@ -88,7 +82,7 @@ if __name__ == '__main__':
                      .labels(**prom_labels)
                      .set(usage['used']))
                     print(rse['rse'], country, rse_type, source, usage['used'])
-                      
+
                 # export and push `MinFreeSpace` value from RSE limits
                 if limits.get('MinFreeSpace'):
                     source = 'min_free_space'

--- a/cms/utils.py
+++ b/cms/utils.py
@@ -1,12 +1,17 @@
 #!/usr/bin/env python3
-# Copyright European Organization for Nuclear Research (CERN) 2020
+# Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
-# You may not use this file except in compliance with the License.
-# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 #
-# Authors:
-# - Eric Vaandering, <ewv@fnal.gov>, 2022
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 
 import os

--- a/common/check_deletable_replicas
+++ b/common/check_deletable_replicas
@@ -1,13 +1,17 @@
 #!/usr/bin/env python
-# Copyright European Organization for Nuclear Research (CERN) 2013
+# Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
-# You may not use this file except in compliance with the License.
-# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 #
-# Authors:
-# - Mario Lassnig, <mario.lassnig@cern.ch>, 2013-2014
-# - Cedric Serfon, <cedric.serfon@cern.ch>, 2018
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 '''
 Probe to check the queues of messages to submit by Hermes to the broker

--- a/common/check_deletable_replicas
+++ b/common/check_deletable_replicas
@@ -18,6 +18,7 @@ Probe to check the queues of messages to submit by Hermes to the broker
 '''
 
 from __future__ import print_function
+
 import sys
 
 from rucio.db.sqla.session import get_session

--- a/common/check_expired_dids
+++ b/common/check_expired_dids
@@ -1,14 +1,17 @@
 #!/usr/bin/env python
-# Copyright European Organization for Nuclear Research (CERN) 2013
+# Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
-# You may not use this file except in compliance with the License.
-# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 #
-# Authors:
-# - Vincent Garonne, <vincent.garonne@cern.ch>, 2013
-# - Thomas Beermann, <thomas.beermann@cern.ch>, 2019
-# - Eric Vaandering <ewv@fnal.gov>, 2020-2021
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 """
 Probe to check the backlog of expired dids.

--- a/common/check_expired_dids
+++ b/common/check_expired_dids
@@ -23,6 +23,7 @@ import traceback
 from datetime import datetime
 
 from prometheus_client import CollectorRegistry, Gauge, push_to_gateway
+
 from rucio.common.config import config_get
 from rucio.db.sqla import models
 from rucio.db.sqla.session import get_session

--- a/common/check_expired_locked_rules
+++ b/common/check_expired_locked_rules
@@ -1,12 +1,17 @@
 #!/usr/bin/env python
-# Copyright European Organization for Nuclear Research (CERN) 2013
+# Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
-# You may not use this file except in compliance with the License.
-# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 #
-# Authors:
-# - Cedric Serfon, <cedric.serfon@cern.ch>, 2015
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 '''
 Probe to check the locked expired rules or datasets with locked rules

--- a/common/check_expired_locked_rules
+++ b/common/check_expired_locked_rules
@@ -18,6 +18,7 @@ Probe to check the locked expired rules or datasets with locked rules
 '''
 
 import sys
+
 from rucio.db.sqla.session import get_session
 
 # Exit statuses

--- a/common/check_expired_rules
+++ b/common/check_expired_rules
@@ -1,14 +1,17 @@
 #!/usr/bin/env python3
-# Copyright European Organization for Nuclear Research (CERN) 2013
+# Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
-# You may not use this file except in compliance with the License.
-# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 #
-# Authors:
-# - Vincent Garonne, <vincent.garonne@cern.ch>, 2013
-# - Thomas Beermann, <thomas.beermann@cern.ch>, 2019
-# - Eric Vaandering, <ewv@fnal.gov>, 2020-2023
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 """
 Probe to check the backlog of expired rules.

--- a/common/check_free_space
+++ b/common/check_free_space
@@ -20,7 +20,7 @@ Probe to check the min free space.
 import sys
 import traceback
 
-from rucio.core.rse import list_rses, get_rse_limits, set_rse_usage
+from rucio.core.rse import get_rse_limits, list_rses, set_rse_usage
 
 # Exit statuses
 OK, WARNING, CRITICAL, UNKNOWN = 0, 1, 2, 3

--- a/common/check_free_space
+++ b/common/check_free_space
@@ -1,12 +1,17 @@
 #!/usr/bin/env python
-# Copyright European Organization for Nuclear Research (CERN) 2013
+# Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
-# You may not use this file except in compliance with the License.
-# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 #
-# Authors:
-# - Vincent Garonne, <vincent.garonne@cern.ch>, 2015
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 '''
 Probe to check the min free space.

--- a/common/check_fts_backlog
+++ b/common/check_fts_backlog
@@ -1,18 +1,17 @@
 #!/usr/bin/env python
-"""
- Copyright European Organization for Nuclear Research (CERN) 2013
-
- Licensed under the Apache License, Version 2.0 (the "License");
- You may not use this file except in compliance with the License.
- You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
-
- Authors:
- - Cedric Serfon, <cedric.serfon@cern.ch>, 2014-2018
- - Mario Lassnig, <mario.lassnig@cern.ch>, 2015
- - Eric Vaandering, <ewv@fnal.gov>, 2019-2021
- - Thomas Beermann, <thomas.beermann@cern.ch>, 2019
-"""
-from __future__ import print_function
+# Copyright European Organization for Nuclear Research (CERN) since 2012
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 import os
 import sys
@@ -143,7 +142,7 @@ if __name__ == "__main__":
                                                                                                + summary['staging']
                                                                                                + summary['started'])
 
-                g.labels(**{'hostname': hostname}).set((summary['submitted'] + summary['active'] + summary['staging'] + summary['started']))
+                g.labels(**{'hostname': hostname}).set(summary['submitted'] + summary['active'] + summary['staging'] + summary['started'])
                 retvalue = OK
                 break
             except Exception as error:

--- a/common/check_fts_backlog
+++ b/common/check_fts_backlog
@@ -18,12 +18,14 @@ import sys
 
 import requests
 import urllib3
+
 try:
     from urlparse import urlparse
 except ImportError:
     from urllib.parse import urlparse
 
 from prometheus_client import CollectorRegistry, Gauge, push_to_gateway
+
 from rucio.common.config import config_get, config_get_bool
 from rucio.core.distance import update_distances
 from rucio.db.sqla.session import BASE, get_session

--- a/common/check_messages_to_submit
+++ b/common/check_messages_to_submit
@@ -1,13 +1,17 @@
 #!/usr/bin/env python
-# Copyright European Organization for Nuclear Research (CERN) 2013
+# Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
-# You may not use this file except in compliance with the License.
-# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 #
-# Authors:
-# - Mario Lassnig, <mario.lassnig@cern.ch>, 2013-2014
-# - Thomas Beermann, <thomas.beermann@cern.ch>, 2019
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 """
 Probe to check the queues of messages to submit by Hermes to the broker

--- a/common/check_messages_to_submit
+++ b/common/check_messages_to_submit
@@ -21,6 +21,7 @@ from __future__ import print_function
 import sys
 
 from prometheus_client import CollectorRegistry, Gauge, push_to_gateway
+
 from rucio.common.config import config_get
 from rucio.db.sqla.session import BASE, get_session
 

--- a/common/check_new_dids
+++ b/common/check_new_dids
@@ -1,14 +1,17 @@
 #!/usr/bin/env python
-# Copyright European Organization for Nuclear Research (CERN) 2013
+# Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
-# You may not use this file except in compliance with the License.
-# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 #
-# Authors:
-# - Vincent Garonne, <vincent.garonne@cern.ch>, 2013
-# - Thomas Beermann, <thomas.beermann@cern.ch>, 2019
-# - Eric Vaandering <ewv@fnal.gov>, 2020
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 """
 Probe to check the backlog of new dids.

--- a/common/check_new_dids
+++ b/common/check_new_dids
@@ -22,6 +22,7 @@ import sys
 import traceback
 
 from prometheus_client import CollectorRegistry, Gauge, push_to_gateway
+
 from rucio.common.config import config_get
 from rucio.db.sqla import models
 from rucio.db.sqla.session import get_session

--- a/common/check_obsolete_replicas
+++ b/common/check_obsolete_replicas
@@ -1,13 +1,17 @@
 #!/usr/bin/env python
-# Copyright European Organization for Nuclear Research (CERN) 2013
+# Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
-# You may not use this file except in compliance with the License.
-# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 #
-# Authors:
-# - Vincent Garonne, <vincent.garonne@cern.ch>, 2015
-# - Cedric Serfon, <cedric.serfon@cern.ch>, 2018
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 '''
 Probe to check the backlog of obsolete replicas.

--- a/common/check_oracle
+++ b/common/check_oracle
@@ -1,14 +1,17 @@
 #!/usr/bin/env python
-# Copyright European Organization for Nuclear Research (CERN) 2013
+# Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
-# You may not use this file except in compliance with the License.
-# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 #
-# Authors:
-# - Vincent Garonne, <vincent.garonne@cern.ch>, 2013
-# - Cedric Serfon, <cedric.serfon@cern.ch>, 2014
-# - Eric Vaandering, <ewv@fnal.gov>, 2019
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 
 """

--- a/common/check_oracle
+++ b/common/check_oracle
@@ -23,6 +23,7 @@ import re
 import sys
 
 import cx_Oracle
+
 from rucio.common.config import config_get
 
 from utils.common import probe_metrics

--- a/common/check_requests_to_rses
+++ b/common/check_requests_to_rses
@@ -1,13 +1,17 @@
 #!/usr/bin/env python
-# Copyright European Organization for Nuclear Research (CERN) 2013
+# Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
-# You may not use this file except in compliance with the License.
-# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 #
-# Authors:
-# - Wen Guan, <wguan@cern.ch>, 2014
-# - Eric Vaandering, <ewv@fnal.gov>, 2019
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 """
 Probe to check requests.

--- a/common/check_stuck_rules
+++ b/common/check_stuck_rules
@@ -1,14 +1,17 @@
 #!/usr/bin/env python
-# Copyright European Organization for Nuclear Research (CERN) 2013
+# Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
-# You may not use this file except in compliance with the License.
-# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 #
-# Authors:
-# - Martin Barisits, <martin.barisits@cern.ch>, 2014
-# - Eric Vaandering, <ewv@fnal.gov>, 2019-2021
-# - Thomas Beermann, <thomas.beermann@cern.ch>, 2019
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 """
 Probe to check the backlog of stuck rules.

--- a/common/check_stuck_rules
+++ b/common/check_stuck_rules
@@ -22,6 +22,7 @@ import sys
 import traceback
 
 from prometheus_client import CollectorRegistry, Gauge, push_to_gateway
+
 from rucio.common.config import config_get
 from rucio.db.sqla.session import BASE, get_session
 

--- a/common/check_transfer_queues_status
+++ b/common/check_transfer_queues_status
@@ -21,6 +21,7 @@ from __future__ import print_function
 import sys
 
 from prometheus_client import CollectorRegistry, Gauge, push_to_gateway
+
 from rucio.common.config import config_get
 from rucio.db.sqla.session import BASE, get_session
 

--- a/common/check_transfer_queues_status
+++ b/common/check_transfer_queues_status
@@ -1,15 +1,17 @@
 #!/usr/bin/env python
-# Copyright European Organization for Nuclear Research (CERN) 2013
+# Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
-# You may not use this file except in compliance with the License.
-# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 #
-# Authors:
-# - Mario Lassnig, <mario.lassnig@cern.ch>, 2013-2021
-# - Cedric Serfon, <cedric.serfon@cern.ch>, 2014
-# - Wen Guan, <wen.guan@cern.ch>, 2015
-# - Thomas Beermann, <thomas.beermann@cern.ch>, 2019
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 """
 Probe to check the queues of the transfer service

--- a/common/check_unevaluated_dids
+++ b/common/check_unevaluated_dids
@@ -1,13 +1,17 @@
 #!/usr/bin/env python
-# Copyright European Organization for Nuclear Research (CERN) 2013
+# Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
-# You may not use this file except in compliance with the License.
-# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 #
-# Authors:
-# - Vincent Garonne, <vincent.garonne@cern.ch>, 2013
-# - Thomas Beermann, <thomas.beermann@cern.ch>, 2019
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 """
 Probe to check the backlog of dids waiting for rule evaluation.

--- a/common/check_unevaluated_dids
+++ b/common/check_unevaluated_dids
@@ -21,6 +21,7 @@ from __future__ import print_function
 import sys
 
 from prometheus_client import CollectorRegistry, Gauge, push_to_gateway
+
 from rucio.common.config import config_get
 from rucio.db.sqla.session import BASE, get_session
 

--- a/common/check_unlocked_replicas
+++ b/common/check_unlocked_replicas
@@ -1,13 +1,17 @@
 #!/usr/bin/env python
-# Copyright European Organization for Nuclear Research (CERN) 2013
+# Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
-# You may not use this file except in compliance with the License.
-# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 #
-# Authors:
-# - Vincent Garonne, <vincent.garonne@cern.ch>, 2013
-# - Thomas Beermann, <thomas.beermann@cern.ch>, 2019
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 """
 Probe to check the backlog of unlocked replicas.

--- a/common/check_unlocked_replicas
+++ b/common/check_unlocked_replicas
@@ -21,6 +21,7 @@ from __future__ import print_function
 import sys
 
 from prometheus_client import CollectorRegistry, Gauge, push_to_gateway
+
 from rucio.common.config import config_get
 from rucio.db.sqla.session import BASE, get_session
 

--- a/common/check_updated_dids
+++ b/common/check_updated_dids
@@ -1,14 +1,17 @@
 #!/usr/bin/env python
-# Copyright European Organization for Nuclear Research (CERN) 2013
+# Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
-# You may not use this file except in compliance with the License.
-# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 #
-# Authors:
-# - Vincent Garonne, <vincent.garonne@cern.ch>, 2013
-# - Thomas Beermann, <thomas.beermann@cern.ch>, 2019
-# - Eric Vaandering <ewv@fnal.gov>, 2020-2021
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 """
 Probe to check the backlog of updated dids.

--- a/common/check_updated_dids
+++ b/common/check_updated_dids
@@ -22,6 +22,7 @@ import sys
 import traceback
 
 from prometheus_client import CollectorRegistry, Gauge, push_to_gateway
+
 from rucio.common.config import config_get
 from rucio.db.sqla import models
 from rucio.db.sqla.session import get_session

--- a/common/utils/__init__.py
+++ b/common/utils/__init__.py
@@ -1,0 +1,13 @@
+# Copyright European Organization for Nuclear Research (CERN) since 2012
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/common/utils/common.py
+++ b/common/utils/common.py
@@ -1,12 +1,17 @@
 #!/usr/bin/env python
-# Copyright European Organization for Nuclear Research (CERN) 2020
+# Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
-# You may not use this file except in compliance with the License.
-# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 #
-# Authors:
-# - Eric Vaandering, <ewv@fnal.gov>, 2022
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 import json
 from typing import Tuple, Dict, List, Optional

--- a/common/utils/common.py
+++ b/common/utils/common.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 import json
-from typing import Tuple, Dict, List, Optional
+from typing import Dict, List, Optional, Tuple
 
 from rucio.common.config import config_get
 from rucio.core.monitor import MetricManager

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,96 @@
+exclude = [
+    ".bzr",
+    ".direnv",
+    ".eggs",
+    ".git",
+    ".git-rewrite",
+    ".hg",
+    ".ipynb_checkpoints",
+    ".mypy_cache",
+    ".nox",
+    ".pants.d",
+    ".pyenv",
+    ".pytest_cache",
+    ".pytype",
+    ".ruff_cache",
+    ".svn",
+    ".tox",
+    ".venv",
+    ".vscode",
+    "__pypackages__",
+    "_build",
+    "buck-out",
+    "build",
+    "dist",
+    "node_modules",
+    "site-packages",
+    "venv",
+    "./attic"
+]
+
+line-length = 256
+
+[lint]
+select = [
+    "I", # isort
+    "S", # bandit
+    "UP", # pyupgrade
+    "TID", # flake8-tidy-imports
+]
+
+ignore = [
+    "ALL",
+    "UP008", # Use `super()` instead of `super(__class__, self)`
+    "UP015", # Unnecessary open mode parameters
+    "UP027", # Replace unpacked list comprehension with a generator expression
+    "UP028", # Replace `yield` over `for` loop with `yield from`
+    "UP030", # Use implicit references for positional format fields
+    "UP031", # Use format specifiers instead of percent format
+    "UP032", # Use f-string instead of `format` call
+    "UP037", # Remove quotes from type annotation. Seeing possible false positives caused by https://github.com/astral-sh/ruff/pull/11485
+    "S603",  # Pending https://github.com/astral-sh/ruff/issues/4045
+    "SIM210",
+]
+
+[lint.isort]
+known-first-party = ["rucio"]
+known-local-folder = ["utils"]
+
+[lint.flake8-tidy-imports.banned-api]
+"typing.AbstractSet".msg = "Use `collections.abc.Set` instead."
+"typing.AsyncContextManager".msg = "Use `contextlib.AbstractAsyncContextManager` instead."
+"typing.AsyncGenerator".msg = "Use `collections.abc.AsyncGenerator` instead."
+"typing.AsyncIterable".msg = "Use `collections.abc.AsyncIterable` instead."
+"typing.AsyncIterator".msg = "Use `collections.abc.AsyncIterator` instead."
+"typing.Awaitable".msg = "Use `collections.abc.Awaitable` instead."
+"typing.Callable".msg = "Use `collections.abc.Callable` instead."
+"typing.ChainMap".msg = "Use `collections.ChainMap` instead."
+"typing.Collection".msg = "Use `collections.abc.Collection` instead."
+"typing.Container".msg = "Use `collections.abc.Container` instead."
+"typing.ContextManager".msg = "Use `contextlib.AbstractContextManager` instead."
+"typing.Coroutine".msg = "Use `collections.abc.Coroutine` instead."
+"typing.Counter".msg = "Use `collections.Counter` instead."
+"typing.DefaultDict".msg = "Use `collections.defaultdict` instead."
+"typing.Deque".msg = "Use `collections.deque` instead."
+"typing.Dict".msg = "Use built-in type `dict` instead. (note: to annotate arguments, the abstract collection type `collections.abc.Mapping` is preferred, if possible. See: https://docs.python.org/3/library/typing.html#typing.Dict)"
+"typing.FrozenSet".msg = "Use built-in type `frozenset` instead."
+"typing.Generator".msg = "Use `collections.abc.Generator` instead."
+"typing.ItemsView".msg = "Use `collections.abc.ItemsView` instead."
+"typing.Iterable".msg = "Use `collections.abc.Iterable` instead."
+"typing.Iterator".msg = "Use `collections.abc.Iterator` instead."
+"typing.KeysView".msg = "Use `collections.abc.KeysView` instead."
+"typing.List".msg = "Use built-in type `list` instead. (note: to annotate arguments, abstract collection types such as `collections.abc.Sequence` and `collections.abc.Iterable` are preferred, if possible. See: https://docs.python.org/3/library/typing.html#typing.List)"
+"typing.Mapping".msg = "Use `collections.abc.Mapping` instead."
+"typing.MappingView".msg = "Use `collections.abc.MappingView` instead."
+"typing.Match".msg = "Use `re.Match` instead."
+"typing.MutableMapping".msg = "Use `collections.abc.MutableMapping` instead."
+"typing.MutableSequence".msg = "Use `collections.abc.MutableSequence` instead."
+"typing.MutableSet".msg = "Use `collections.abc.MutableSet` instead."
+"typing.OrderedDict".msg = "Use `collections.OrderedDict` instead."
+"typing.Pattern".msg = "Use `re.Pattern` instead."
+"typing.Reversible".msg = "Use `collections.abc.Reversible` instead."
+"typing.Sequence".msg = "Use `collections.abc.Sequence` instead."
+"typing.Set".msg = "Use built-in type `set` instead. (note: to annotate arguments, the abstract collection type `collections.abc.AbstractSet` is preferred, if possible. See: https://docs.python.org/3/library/typing.html#typing.Set)"
+"typing.Tuple".msg = "Use built-in type `tuple` instead."
+"typing.Type".msg = "Use built-in `type` instead."
+"typing.ValuesView".msg = "Use `collections.abc.ValuesView` instead."


### PR DESCRIPTION
Addresses #141 

Looks huge but it's just sorting imports according to the ruff settings from the main repo and adding headers to everything except probes in the attic. Doesn't address any of the concerns the pre-commits (either flake8 or ruff) bring up. 

