### PR TITLE
Common: Rewrite check_unlocked_replicas

### DIFF
--- a/common/check_unlocked_replicas
+++ b/common/check_unlocked_replicas
@@ -1,69 +1,62 @@
-#!/usr/bin/env python
-# Copyright European Organization for Nuclear Research (CERN) 2013
+#!/usr/bin/env python3
+# Copyright European Organization for Nuclear Research (CERN) since 2012
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
-# You may not use this file except in compliance with the License.
-# You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 #
-# Authors:
-# - Vincent Garonne, <vincent.garonne@cern.ch>, 2013
-# - Thomas Beermann, <thomas.beermann@cern.ch>, 2019
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 """
 Probe to check the backlog of unlocked replicas.
 """
-from __future__ import print_function
 
 import sys
+from datetime import datetime
+import traceback
+from sqlalchemy import func, select, null, and_
 
-from prometheus_client import CollectorRegistry, Gauge, push_to_gateway
-from rucio.common.config import config_get
-from rucio.db.sqla.session import BASE, get_session
+from rucio.db.sqla import models
+from rucio.db.sqla.session import get_session
 
-from utils.common import probe_metrics
+from utils.common import PrometheusPusher
 
 # Exit statuses
 OK, WARNING, CRITICAL, UNKNOWN = 0, 1, 2, 3
 
-# select (select rse from "ATLAS_RUCIO".rses where id = rse_id),
-#       n
-# from
-# (SELECT /*+ index_FFS(replicas REPLICAS_TOMBSTONE_IDX) */
-#      CASE WHEN ("ATLAS_RUCIO".replicas.tombstone IS NOT NULL) THEN "ATLAS_RUCIO".replicas.rse_id END as rse_id,
-#      count(*) as n
-# FROM "ATLAS_RUCIO".replicas
-# WHERE "ATLAS_RUCIO".replicas.tombstone is not null
-# GROUP BY CASE WHEN ("ATLAS_RUCIO".replicas.tombstone IS NOT NULL) THEN "ATLAS_RUCIO".replicas.rse_id END)
-
-if BASE.metadata.schema:
-    schema = BASE.metadata.schema + '.'
-else:
-    schema = ''
-
-PROM_SERVERS = config_get('monitor', 'prometheus_servers', raise_exception=False, default='')
-if PROM_SERVERS != '':
-    PROM_SERVERS = PROM_SERVERS.split(',')
-
 if __name__ == "__main__":
     try:
-        registry = CollectorRegistry()
         session = get_session()
-        unlocked_sql = 'select  /*+ index_ffs(replicas REPLICAS_TOMBSTONE_IDX) */  count(1) from {schema}replicas where tombstone is not null'.format(schema=schema)
-        result = session.execute(unlocked_sql).fetchone()[0]
-        probe_metrics.gauge(name='reaper.unlocked_replicas').set(result)
-        Gauge('reaper_unlocked_replicas', '', registry=registry).set(result)
-        print(result)
-        expired_sql = 'select  /*+ index_ffs(replicas REPLICAS_TOMBSTONE_IDX) */  count(1) from {schema}replicas where tombstone is not null and tombstone < sysdate - 2/24'.format(schema=schema)
-        result = session.execute(expired_sql).fetchone()[0]
-        probe_metrics.gauge(name='reaper.unlocked_replicas').set(result)
-        Gauge('reaper_expired_replicas', '', registry=registry).set(result)
+        base_statement =  select(
+            func.count()
+        ).select_from(
+            models.RSEFileAssociation
+        )
+        # Expired replicas 
+        statement = base_statement.where(
+            and_(
+                models.RSEFileAssociation.tombstone != null(),
+                models.RSEFileAssociation.tombstone < datetime.utcnow()
+            )
+        )
+        expired_replicas = session.execute(statement).scalar_one()
+        
+        # Unlocked replicas
+        statement = base_statement.where(
+            models.RSEFileAssociation.tombstone != null()
+        )
+        unlocked_replicas = session.execute(statement).scalar_one()
 
-        if len(PROM_SERVERS):
-            for server in PROM_SERVERS:
-                try:
-                    push_to_gateway(server.strip(), job='check_unlocked_replicas', registry=registry)
-                except:
-                    continue
-    except:
+        with PrometheusPusher() as manager:
+            manager.gauge("reaper.expired_replicas").set(expired_replicas)
+            manager.gauge("reaper.unlocked_replicas").set(unlocked_replicas)
+    except Exception:
+        print(traceback.format_exc())
         sys.exit(UNKNOWN)
     sys.exit(OK)


### PR DESCRIPTION
* Use sqla2.0 (broken into base statement and modifications)
* Change gauge to prometheuspusher
* Update Header
* Sort imports
* change except to except Exception

Updated queries compile to: 

```
SELECT count(*) AS count_1 
FROM dev.replicas 
WHERE dev.replicas.tombstone IS NOT NULL AND dev.replicas.tombstone < :tombstone_1

SELECT count(*) AS count_1 
FROM dev.replicas 
WHERE dev.replicas.tombstone IS NOT NULL
```

The query for expired replicas has the extra condition `tombstone < sysdate - 2/24'` but I can't get my head around why that offset (of milliseconds?) is there to begin with, so if there need to be modifications let me know. 